### PR TITLE
Only deploy action output on push to main

### DIFF
--- a/.github/workflows/deploy-action-output-to-s3.yml
+++ b/.github/workflows/deploy-action-output-to-s3.yml
@@ -3,10 +3,16 @@ on: [push]
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-    name: A job to run the action to ensure it works
+    name: A job to run the action and deploy it's output file to the sample s3 bucket
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
       - name: Run Action
         uses: ./ 
         with: 
@@ -14,3 +20,5 @@ jobs:
           data-url: https://gist.githubusercontent.com/joshmsamuels/96e1424acbe7e935493456c8d7b41ed1/raw/b80a57f73a4f5816a1b374170972740cccb96d39/populate-template-action-sample-data.json
           variable-tags: "{\"start\": \"<<\", \"end\": \">>\"}"
           output-filename: sample-file.pdf
+      - name: Deploy
+        run: aws s3 cp ./sample-file.pdf s3://joshmsamuels.populate-template-action.test-bucket


### PR DESCRIPTION
Until today every time the action "e2e test" was run it would push the file to the S3 bucket. The purpose of that file is to ensure the action works correctly, not that the deploying to s3 works.

I believe this is the right time to only push updated files to s3 on pushes to main since I have manually verified that the flow works and the latex file is rendered correctly. My assumption going forward will be that any issues with the compilation of the latex files will fail the build.